### PR TITLE
add shortcut to link as webapp

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "link": "ln -s $PWD/out $HOME/.signalk/node_modules/ocearo-ui"
   },
   "dependencies": {
     "@fortawesome/free-solid-svg-icons": "^6.7.2",


### PR DESCRIPTION
Add shortcut npm run link to link the out
directory as Signal K webapp under default
location /Users/tjk/.signalk/node_modules.

Simple `npm link` does not work, as it seems that next build is hardcoded to use static assets from `public` and SK server is hardcoded to use `public` as the directory for web assets (if it exists).